### PR TITLE
Centralize package version management

### DIFF
--- a/Core/Application/Application.csproj
+++ b/Core/Application/Application.csproj
@@ -11,11 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper" Version="13.0.1" />
-    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
-    <PackageReference Include="MediatR" Version="12.4.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="AutoMapper" />
+    <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
+    <PackageReference Include="MediatR"  />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,57 @@
+<Project>
+  
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+	
+  <ItemGroup>
+    <PackageVersion Include="AutoMapper" Version="13.0.1" />
+	  
+    <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="11.9.2" />
+	  
+    <PackageVersion Include="MediatR" Version="12.4.1" />
+	  
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
+	  
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
+	  
+    <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.8" />
+	  
+    <PackageVersion Include="Microsoft.AspNetCore.OData" Version="9.0.0" />
+	  
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
+	  
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
+	  
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
+	  
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+	  
+    <PackageVersion Include="MimeKit" Version="4.8.0" />
+	  
+    <PackageVersion Include="MySql.Data" Version="9.0.0" />
+	  
+    <PackageVersion Include="NETCore.MailKit" Version="2.1.0" />
+	  
+    <PackageVersion Include="Npgsql" Version="8.0.3" />
+	  
+    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
+	  
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
+	  
+    <PackageVersion Include="SequentialGuid" Version="4.0.5" />
+	  
+    <PackageVersion Include="Serilog" Version="4.0.1" />
+	  
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
+	  
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="8.0.2" />
+	  
+    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
+	  
+    <PackageVersion Include="System.Linq.Dynamic.Core" Version="1.6.0.1" />
+	  
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+  </ItemGroup>
+
+</Project>

--- a/Indotalent.sln
+++ b/Indotalent.sln
@@ -17,6 +17,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebAPI", "Presentation\WebA
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Infrastructure", "Infrastructure\Infrastructure\Infrastructure.csproj", "{D104F1FC-C447-4E02-AF82-FC6A2B8DC614}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{479E2EF7-6265-43D8-AADD-6FACD8DC54A1}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.props = Directory.Packages.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Infrastructure/Infrastructure/Infrastructure.csproj
+++ b/Infrastructure/Infrastructure/Infrastructure.csproj
@@ -7,25 +7,25 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.OData" Version="9.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.1" />
-    <PackageReference Include="MimeKit" Version="4.8.0" />
-    <PackageReference Include="MySql.Data" Version="9.0.0" />
-    <PackageReference Include="NETCore.MailKit" Version="2.1.0" />
-    <PackageReference Include="Npgsql" Version="8.0.3" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.4" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="8.0.2" />
-    <PackageReference Include="SequentialGuid" Version="4.0.5" />
-    <PackageReference Include="Serilog" Version="4.0.1" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="8.0.2" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="System.Linq.Dynamic.Core" Version="1.6.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer"  />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore"  />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.UI"  />
+    <PackageReference Include="Microsoft.AspNetCore.OData"  />
+    <PackageReference Include="Microsoft.EntityFrameworkCore"  />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"  />
+    <PackageReference Include="MimeKit"  />
+    <PackageReference Include="MySql.Data" />
+    <PackageReference Include="NETCore.MailKit"  />
+    <PackageReference Include="Npgsql"  />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql"  />
+    <PackageReference Include="SequentialGuid" />
+    <PackageReference Include="Serilog"  />
+    <PackageReference Include="Serilog.Extensions.Logging"  />
+    <PackageReference Include="Serilog.Settings.Configuration"  />
+    <PackageReference Include="Serilog.Sinks.File"  />
+    <PackageReference Include="System.Linq.Dynamic.Core"  />
   </ItemGroup>
 
   <ItemGroup>

--- a/Presentation/WebAPI/WebAPI.csproj
+++ b/Presentation/WebAPI/WebAPI.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Removed specific version numbers from `PackageReference` elements in `Application.csproj`, `Infrastructure.csproj`, and `WebAPI.csproj` to allow central management. Updated `Indotalent.sln` to include a new project section for "Solution Items" and added a reference to `Directory.Packages.props`. Added `Directory.Packages.props` to manage package versions centrally.